### PR TITLE
Packaging of java runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,21 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Java JDK 8
-        uses: actions/setup-java@v1.3.0
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.1
         with:
-          java-version: 8
+          java-version: 14
       - name: Gradle Build
-        run: gradle build
-      - name: Generate Bash Completion
-        env:
-          OPEN_CUE_CLI_COMPLETE: bash
-        run: |
-          unzip build/distributions/open-cue-cli.zip
-          ./open-cue-cli/open-cue-cli > open-cue-cli/bash-complete-open-cue-cli.sh
-          chmod +x open-cue-cli/bash-complete-open-cue-cli.sh
+        run: gradle runtimeZip
       - name: Upload distribution archive
         uses: actions/upload-artifact@v2
         with:
           name: open-cue-cli
-          path: open-cue-cli/
+          path: build/open-cue-cli-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,32 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Java JDK 8
-        uses: actions/setup-java@v1.3.0
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.1
         with:
-          java-version: 8
+          java-version: 14
       - name: Gradle Build
-        run: gradle build
-      - name: Generate Bash Completion
-        env:
-          OPEN_CUE_CLI_COMPLETE: bash
-        run: |
-          unzip build/distributions/open-cue-cli.zip
-          ./open-cue-cli/open-cue-cli > open-cue-cli/bash-complete-open-cue-cli.sh
-          chmod +x open-cue-cli/bash-complete-open-cue-cli.sh
-          zip -r open-cue-cli.zip open-cue-cli
+        run: gradle runtimeZip
       - name: Get upload url
         id: release-id
         run: |
           RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
           echo "::set-output name=upload_url::https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets{?name,label}"
-      - name: Upload Release Asset
+      - name: Upload Release Assets
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: bgpat/release-asset-action@03b0c30db1c4031ce3474740b0e4275cd7e126a3
         with:
-          upload_url: ${{ steps.release-id.outputs.upload_url }}
-          asset_path: open-cue-cli.zip
-          asset_name: open-cue-cli.zip
-          asset_content_type: application/zip
+          pattern: build/open-cue-cli-*.zip
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-url: ${{ steps.release-id.outputs.upload_url }}
+          allow-overwrite: true

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,6 @@ You can use all your customized iCUE profiles.
 ## Getting Started
 Download and start the [Open CUE Service](https://github.com/Legion2/open-cue-service).
 Download the [latest release](https://github.com/Legion2/open-cue-cli/releases/latest) of Open CUE CLI and extract the archive.
-You must at least have Java 8 installed.
 Call the cli tool `open-cue-cli.bat` or `open-cue-cli` from a command prompt with the option `--help`.
 
 ```
@@ -67,9 +66,8 @@ You must set the name of the profile, when you export it from iCUE, you can't ch
 The priorities comes into play when you activate two profiles, then the profile with the higher priority is shown on top of the other.
 
 ## Packaging of this application
-This package is provide as zip containing executables and dependencies as jars.
-A Java Runtime Environment (JRE) must be installed to run the application.
-Just download the zip archive, extract it where you want and then execute one of the executable scripts from the extracted archive.
+This package is provide as zip containing optimized runtime images.
+Just download the [zip archive for your platform](https://github.com/Legion2/open-cue-cli/releases), extract it where you want and then execute one of the executable scripts from the extracted archive.
 
 ### Why not provide native executable
 Native executables require curl or other native implementations to do http calls.

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ These profiles are just the exported files when you export a profile in iCUE.
 When export profiles from iCUE only select "Lighting Effects" in the export settings.
 
 Profiles are grouped into games, this is because the SDK was designed for iCUE Game integration.
-So each subdirectory of `GameSdkEffects` represent a game and contains all it's profiles and a `priorities.cfg` file.
+So each subdirectory of `GameSdkEffects` represent a game and contains all its profiles and a `priorities.cfg` file.
 
 ### Use own profiles/effects
 The subdirectories of `GameSdkEffects` correspond to games, but you can also create own subdirectories.
@@ -66,7 +66,7 @@ You must set the name of the profile, when you export it from iCUE, you can't ch
 The priorities comes into play when you activate two profiles, then the profile with the higher priority is shown on top of the other.
 
 ## Packaging of this application
-This package is provide as zip containing optimized runtime images.
+This package is provide as zip containing optimized executable runtime image.
 Just download the [zip archive for your platform](https://github.com/Legion2/open-cue-cli/releases), extract it where you want and then execute one of the executable scripts from the extracted archive.
 
 ### Why not provide native executable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.3.72"
+    kotlin("jvm") version "1.4.0"
     application
+    id("org.beryx.runtime") version "1.11.2"
 }
 
 repositories {
@@ -14,11 +15,35 @@ application {
     applicationName = "open-cue-cli"
 }
 
+runtime {
+    addModules("java.base",
+            "java.sql",//because of gson
+            "jdk.unsupported"//https://stackoverflow.com/questions/61727613/unexpected-behaviour-from-gson
+    )
+
+    imageZip.set(file("$buildDir/${project.application.applicationName}.zip"))
+    targetPlatform("linux-x64") {
+        setJdkHome(jdkDownload("https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz"))
+    }
+    targetPlatform("linux-aarch64") {
+        setJdkHome(jdkDownload("https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz"))
+    }
+    targetPlatform("linux-arm32") {
+        setJdkHome(jdkDownload("https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_arm_linux_hotspot_14.0.2_12.tar.gz"))
+    }
+    targetPlatform("windows-x64") {
+        setJdkHome(jdkDownload("https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_windows_hotspot_14.0.2_12.zip"))
+    }
+    targetPlatform("mac-x64") {
+        setJdkHome(jdkDownload("https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_mac_hotspot_14.0.2_12.tar.gz"))
+    }
+}
+
 val ktorVersion = "1.3.2"
 val cliktVersion = "2.6.0"
 
 dependencies {
-    implementation("com.github.ajalt:clikt-multiplatform:$cliktVersion")
+    implementation("com.github.ajalt:clikt:$cliktVersion")
     implementation("io.ktor:ktor-client:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-json:$ktorVersion")
@@ -27,14 +52,22 @@ dependencies {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "1.8"
-        languageVersion = "1.3"
-        apiVersion = "1.3"
+        jvmTarget = "14"
+        languageVersion = "1.4"
+        apiVersion = "1.4"
         freeCompilerArgs += "-Xopt-in=com.github.ajalt.clikt.completion.ExperimentalCompletionCandidates"
     }
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "6.3"
+    gradleVersion = "6.6"
     distributionType = Wrapper.DistributionType.ALL
+}
+
+// workaround for https://github.com/beryx/badass-runtime-plugin/issues/67
+tasks.withType<CreateStartScripts> {
+    doLast {
+        windowsScript.writeText(windowsScript.readText()
+                .replace("set JAVA_HOME=\"%~dp0..\"", "set JAVA_HOME=\"%~dp0\""))
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ application {
 }
 
 runtime {
+    addOptions("--strip-debug", "--compress", "2", "--no-header-files", "--no-man-pages")
     addModules("java.base",
             "java.sql",//because of gson
             "jdk.unsupported"//https://stackoverflow.com/questions/61727613/unexpected-behaviour-from-gson

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.ByteArrayOutputStream
+
 plugins {
     kotlin("jvm") version "1.4.0"
     application
@@ -56,6 +58,29 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         languageVersion = "1.4"
         apiVersion = "1.4"
         freeCompilerArgs += "-Xopt-in=com.github.ajalt.clikt.completion.ExperimentalCompletionCandidates"
+    }
+}
+
+val generateCliCompletions by tasks.registering(JavaExec::class) {
+    dependsOn("classes")
+    classpath = sourceSets.main.get().runtimeClasspath
+    main = application.mainClassName
+    environment("OPEN_CUE_CLI_COMPLETE", "bash")
+
+    val completions = file("$buildDir/completions")
+    outputs.dir(completions)
+    doFirst {
+        println("This is executed first during the execution phase.")
+        completions.mkdirs()
+        standardOutput = File(completions, "bash-complete-open-cue-cli.sh").outputStream()
+    }
+}
+
+distributions {
+    main {
+        contents {
+            from(generateCliCompletions)
+        }
     }
 }
 


### PR DESCRIPTION
Add gradle Badass Runtime plugin to create runtime images of java runtime to run the cli without a java runtime installed on the machine. close #2 
Provide pre built images downloadable from the releases.